### PR TITLE
docs: ignite chain build primary, make install alternative + full toolchain prereqs

### DIFF
--- a/documents/chain/readme.md
+++ b/documents/chain/readme.md
@@ -47,51 +47,94 @@ This guide covers three setup scenarios for STOC mainnet:
 
 ## Common Setup (All Scenarios)
 
-### 1. Install Go
+### 1. Install Go 1.25.8+
+
+The project's `go.mod` requires **Go 1.25.8 or newer**.
 
 ```bash
-sudo apt update && sudo apt install -y build-essential jq curl wget
+sudo apt update && sudo apt install -y build-essential jq curl wget git
 
-# Install Go 1.24.3
-wget https://go.dev/dl/go1.24.3.linux-amd64.tar.gz
+# Download and install Go 1.25.8 (Linux amd64 — adjust arch as needed)
+wget https://go.dev/dl/go1.25.8.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.24.3.linux-amd64.tar.gz
-rm go1.24.3.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.25.8.linux-amd64.tar.gz
+rm go1.25.8.linux-amd64.tar.gz
 
 echo 'export GOROOT=/usr/local/go' >> ~/.bashrc
 echo 'export GOPATH=$HOME/go' >> ~/.bashrc
 echo 'export PATH=$PATH:$GOROOT/bin:$GOPATH/bin' >> ~/.bashrc
 source ~/.bashrc
 
-# Verify
+# Verify — must print 1.25.8 or higher
 go version
 ```
 
-### 2. Build stocd
+> For ARM64 (Apple Silicon, ARM VPS) replace `amd64` with `arm64` in the URL.
+
+### 2. Install Ignite CLI v29+
+
+Ignite CLI is the recommended build tool. It auto-regenerates protobuf and links ldflags.
+
+```bash
+curl https://get.ignite.com/cli | bash
+sudo mv ignite /usr/local/bin/
+
+# Verify
+ignite version
+```
+
+If `ignite chain build` later fails with `go: cannot find "go1.25.8" in PATH`, install the Go toolchain launcher so Go's auto-switching mechanism can find the required version:
+
+```bash
+go install golang.org/dl/go1.25.8@latest
+$(go env GOPATH)/bin/go1.25.8 download
+
+# Make sure $GOPATH/bin is in PATH (step 1 added it)
+```
+
+### 3. Build stocd
+
+**Option A — Using Ignite CLI (recommended)**
+
+Fastest path: single command handles proto-gen + tidy + build + install.
 
 ```bash
 git clone https://github.com/STOCHAINAssociation/STOC-Blockchain-Mainnet.git
 cd STOC-Blockchain-Mainnet
 
-# Option A: Using make (recommended)
-make install
-
-# Option B: Using Ignite CLI (requires Ignite v29+)
+# Build and install stocd
 ignite chain build
+
+# Ignite prints a lot of init logs — final line should be:
+#   🗃  Installed. Use with: stocd
 
 # Verify
 stocd version
 ```
 
-> **Alternative**: If you cannot build from source, download the pre-built binary from [here](https://drive.google.com/file/d/1FWjVfsqQ7Y6qR1U2aAIzk0pm08spMiq-/view?usp=sharing).
+> Ignite places the binary in `$(go env GOPATH)/bin/stocd`. Make sure that directory is on your `PATH` (step 1 handled this).
 
-### 3. Initialize Node
+**Option B — Using `make install` (no Ignite required)**
+
+Pure Go path with fewer dependencies. Useful when Ignite is unavailable or when you want a `stocd version` string with branch + commit metadata.
+
+```bash
+cd STOC-Blockchain-Mainnet
+make install
+stocd version
+```
+
+`make install` runs `go install -mod=readonly` with ldflags that embed the branch name and commit hash into the binary — helpful for debugging which build is running on each node.
+
+> **Pre-built binary**: If you cannot build from source, download the latest pre-built binary from [here](https://drive.google.com/file/d/1FWjVfsqQ7Y6qR1U2aAIzk0pm08spMiq-/view?usp=sharing).
+
+### 4. Initialize Node
 
 ```bash
 stocd init <your_moniker_name> --chain-id stoc
 ```
 
-### 4. Download Genesis
+### 5. Download Genesis
 
 ```bash
 curl -s https://rpc-stoc-mainnet.stochainscan.io/genesis | jq '.result.genesis' > ~/.stoc/config/genesis.json
@@ -100,7 +143,7 @@ curl -s https://rpc-stoc-mainnet.stochainscan.io/genesis | jq '.result.genesis' 
 stocd genesis validate ~/.stoc/config/genesis.json
 ```
 
-### 5. Configure Node
+### 6. Configure Node
 
 ```bash
 # Set minimum gas price
@@ -140,7 +183,7 @@ grep -A1 '^\[evm\]' ~/.stoc/config/app.toml
 > curl -s https://api-sync-stoc-mainnet.stochainscan.io/snapshots/addrbook | jq -r '.data.addrs[] | "\(.addr.id)@\(.addr.ip):\(.addr.port)"' | head -10
 > ```
 
-### 6. Setup systemd Service
+### 7. Setup systemd Service
 
 ```bash
 sudo tee /etc/systemd/system/stocd.service > /dev/null <<EOF
@@ -331,7 +374,10 @@ sudo systemctl stop stocd
 # 2. Pull latest source and rebuild
 cd /path/to/STOC-Blockchain-Mainnet
 git pull
-make install
+
+# Rebuild — pick ONE of:
+ignite chain build     # Recommended (auto proto-gen + tidy)
+# make install          # Alternative (pure-Go, faster, no Ignite needed)
 
 # 3. Verify new binary
 stocd version
@@ -370,7 +416,7 @@ sudo systemctl stop stocd
 
 cd /path/to/STOC-Blockchain-Mainnet
 git checkout <tag_or_branch_matching_upgrade>
-make install
+ignite chain build   # or: make install
 
 # Ensure evm-chain-id is set (see Option A step 4)
 sudo systemctl start stocd

--- a/readme.md
+++ b/readme.md
@@ -31,17 +31,30 @@ STOC Chain is a high-performance blockchain with full EVM (Ethereum Virtual Mach
 
 ### Build from Source
 
+Requires **Go 1.25.8+** and **[Ignite CLI v29+](https://docs.ignite.com/welcome/install)**.
+
 ```bash
 # Clone the public repository
 git clone https://github.com/STOCHAINAssociation/STOC-Blockchain-Mainnet.git
 cd STOC-Blockchain-Mainnet
 
-# Build and install stocd binary
+# Recommended: Ignite CLI (auto proto-gen + tidy + install)
+ignite chain build
+
+# Alternative: pure-Go build (no Ignite needed; embeds branch + commit version)
 make install
 
 # Verify
 stocd version
 ```
+
+> If `ignite chain build` reports `go: cannot find "go1.25.8" in PATH`, install the Go toolchain launcher once:
+> ```bash
+> go install golang.org/dl/go1.25.8@latest
+> $(go env GOPATH)/bin/go1.25.8 download
+> ```
+>
+> Full setup instructions (including OS-level Go install) live in the [Node Setup Guide](./documents/chain/readme.md#2-install-ignite-cli-v29).
 
 ### Local Development (Hot Reload)
 
@@ -107,7 +120,8 @@ STOC-Blockchain-Mainnet/
 ## Build & Test Commands
 
 ```bash
-make install        # Build and install stocd
+ignite chain build  # Recommended: build + install stocd (auto proto-gen)
+make install        # Alternative: pure-Go build with branch+commit version
 make test           # Full test suite (vet + vuln + unit)
 make test-unit      # Unit tests only
 make test-race      # Tests with race detection


### PR DESCRIPTION


Public-repo-friendly build docs. End-user operators starting from a clean Ubuntu VPS now have:

- Install Go bumped from 1.24.3 to 1.25.8 (matches go.mod requirement)
- New "Install Ignite CLI v29+" step with the go1.25.8 toolchain launcher workaround (go install golang.org/dl/go1.25.8@latest + download)
- Build section split into:
  - Option A (recommended): ignite chain build — single-command pipeline auto-regenerates protobuf, runs go mod tidy, installs to $GOPATH/bin
  - Option B (alternative): make install — pure-Go build with no Ignite dep, embeds branch+commit version via Makefile ldflags
- Renumbered subsequent setup steps (Init → 4, Genesis → 5, Configure → 6, systemd → 7)
- Upgrade guide (Option A + B) shows both build tools side-by-side
- Top-level readme.md Quick Start mirrors the same pick-ONE layout and links back to the fuller Node Setup Guide for OS-level installs